### PR TITLE
Improve ghost AI behavior

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -209,7 +209,7 @@ void Game::run()
         {
             player_.handleInput();
             player_.update(level_);
-            for(auto& g:ghosts_) g.update(level_);
+            for(auto& g:ghosts_) g.update(level_, player_.position());
 
             for(auto& g:ghosts_){
                 sf::Vector2f d = g.position() - player_.position();

--- a/src/Ghost.hpp
+++ b/src/Ghost.hpp
@@ -8,7 +8,7 @@ class Ghost {
 public:
     Ghost(sf::Color color, sf::Vector2f start);
     void reset();
-    void update(const Level& lvl);
+    void update(const Level& lvl, const sf::Vector2f& target);
     void draw(sf::RenderTarget& rt) const { rt.draw(sprite_); }
     sf::Vector2f position() const { return sprite_.getPosition(); }
 private:
@@ -21,5 +21,6 @@ private:
     sf::Vector2f start_;
     Dir curDir_{Dir::Left};
     bool onTeleport_ = false;
+    int scatterSteps_ = 0;
 };
 


### PR DESCRIPTION
## Summary
- add scatterSteps_ state to Ghost to start with some random movement
- modify Ghost::update to pick random directions when scattering and chase probabilistically thereafter
- align ghost position at tile centers to navigate narrow passages

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6877a305ecfc8327a4765142a9407df5