### PR TITLE
Improve ghost pathfinding

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -209,7 +209,7 @@ void Game::run()
         {
             player_.handleInput();
             player_.update(level_);
-            for(auto& g:ghosts_) g.update(level_);
+            for(auto& g:ghosts_) g.update(level_, player_.position());
 
             for(auto& g:ghosts_){
                 sf::Vector2f d = g.position() - player_.position();

--- a/src/Ghost.cpp
+++ b/src/Ghost.cpp
@@ -2,6 +2,9 @@
 #include <array>
 #include <algorithm>
 #include <cmath>
+#include <limits>
+#include <queue>
+#include <vector>
 
 Ghost::Ghost(sf::Color color, sf::Vector2f start) : start_(start) {
     sprite_.setRadius(PAC_RADIUS);
@@ -46,7 +49,7 @@ Ghost::Dir Ghost::opposite(Dir d){
     }
 }
 
-void Ghost::update(const Level& lvl){
+void Ghost::update(const Level& lvl, const sf::Vector2f& target){
     auto pos = sprite_.getPosition();
     int gx=int(pos.x/TILE), gy=int(pos.y/TILE);
     sf::Vector2f center{TILE*(gx+0.5f),TILE*(gy+0.5f)};
@@ -55,12 +58,65 @@ void Ghost::update(const Level& lvl){
     bool atCenter = std::abs(center.x-pos.x)<1.f && std::abs(center.y-pos.y)<1.f;
     if(!canMove(lvl,next) || atCenter){
         static std::mt19937 rng(std::random_device{}());
-        std::array<Dir,4> d{Dir::Left,Dir::Right,Dir::Up,Dir::Down};
-        std::shuffle(d.begin(), d.end(), rng);
-        for(auto nd:d){
-            if(nd==opposite(curDir_)) continue;
-            if(canMove(lvl,center+dirVec(nd))){ curDir_=nd; break; }
+        std::array<Dir,4> order{Dir::Left,Dir::Right,Dir::Up,Dir::Down};
+        std::shuffle(order.begin(), order.end(), rng);
+
+        int pgx = int(target.x / TILE);
+        int pgy = int(target.y / TILE);
+
+        // BFS from player to compute distances
+        std::vector<std::vector<int>> dist(lvl.height(), std::vector<int>(lvl.width(), -1));
+        std::queue<sf::Vector2i> q;
+        dist[pgy][pgx] = 0;
+        q.push({pgx,pgy});
+        const int dx[4]={-1,1,0,0};
+        const int dy[4]={0,0,-1,1};
+        while(!q.empty()){
+            auto c=q.front();q.pop();
+            int cd = dist[c.y][c.x];
+            for(int i=0;i<4;++i){
+                int nx=c.x+dx[i], ny=c.y+dy[i];
+                if(nx<0||ny<0||nx>=lvl.width()||ny>=lvl.height()) continue;
+                if(!lvl.isWalkable(nx,ny)) continue;
+                if(dist[ny][nx]!=-1) continue;
+                dist[ny][nx]=cd+1;
+                q.push({nx,ny});
+            }
         }
+
+        Dir bestDir = curDir_;
+        int bestCost = std::numeric_limits<int>::max();
+        for(auto nd:order){
+            if(nd==opposite(curDir_)) continue;
+            if(!canMove(lvl,center+dirVec(nd))) continue;
+
+            int dxs=0,dys=0;
+            switch(nd){
+                case Dir::Left: dxs=-1; break;
+                case Dir::Right: dxs=1; break;
+                case Dir::Up: dys=-1; break;
+                case Dir::Down: dys=1; break;
+            }
+            int nx=gx+dxs, ny=gy+dys;
+            int cost = (nx>=0&&ny>=0&&ny<lvl.height()&&nx<lvl.width()) ? dist[ny][nx] : -1;
+            if(cost>=0 && cost < bestCost){
+                bestCost = cost;
+                bestDir = nd;
+            }
+        }
+
+        std::uniform_real_distribution<float> prob(0.f,1.f);
+        if(prob(rng) < 0.3f || bestCost==std::numeric_limits<int>::max()){
+            for(auto nd:order){
+                if(nd==opposite(curDir_)) continue;
+                if(canMove(lvl,center+dirVec(nd))){
+                    bestDir = nd;
+                    break;
+                }
+            }
+        }
+
+        curDir_ = bestDir;
     }
 
     sprite_.move(dirVec(curDir_));

--- a/src/Ghost.hpp
+++ b/src/Ghost.hpp
@@ -8,7 +8,7 @@ class Ghost {
 public:
     Ghost(sf::Color color, sf::Vector2f start);
     void reset();
-    void update(const Level& lvl);
+    void update(const Level& lvl, const sf::Vector2f& target);
     void draw(sf::RenderTarget& rt) const { rt.draw(sprite_); }
     sf::Vector2f position() const { return sprite_.getPosition(); }
 private:


### PR DESCRIPTION
## Summary
- refine ghost AI
- use BFS pathfinding and occasional randomness to loosen pursuit

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6877a305ecfc8327a4765142a9407df5